### PR TITLE
fix: handle null values coming from jito MEV API

### DIFF
--- a/cli/src/metrics_helpers.rs
+++ b/cli/src/metrics_helpers.rs
@@ -34,7 +34,7 @@ pub fn log_validator_mev_data(target_epoch: u64, mev_data: &ValidatorInfo) {
         ("vote_account", mev_data.vote_account, String),
         (
             "mev_commission_bps",
-            mev_data.mev_commission_bps as i64,
+            mev_data.mev_commission_bps.unwrap_or(10_000) as i64,
             i64
         ),
         ("mev_rewards", mev_data.mev_rewards as i64, i64),

--- a/cli/src/rewards/mev_rewards.rs
+++ b/cli/src/rewards/mev_rewards.rs
@@ -10,7 +10,7 @@ use solana_sdk::pubkey::Pubkey;
 #[derive(Clone, Deserialize, Debug)]
 pub struct ValidatorInfo {
     pub vote_account: String,
-    pub mev_commission_bps: u64,
+    pub mev_commission_bps: Option<u64>,
     pub mev_rewards: u64,
     pub running_jito: bool,
     pub active_stake: u64,
@@ -158,7 +158,7 @@ pub fn calculate_excess_mev_reward(
         mev_data.mev_rewards,
         pye_account_active_stake,
         mev_data.active_stake,
-        mev_data.mev_commission_bps,
+        mev_data.mev_commission_bps.unwrap_or(10_000),
         reward_commissions.mev_tips_bps,
     );
     println!("Excess MEV Commission: {}\n", excess_mev_commission);


### PR DESCRIPTION
Starting in epoch 855 null values for _mev_commission_bps_ was observed